### PR TITLE
CLI: export rasters with optional CRS + COG (predict unchanged)

### DIFF
--- a/sdm/cli.py
+++ b/sdm/cli.py
@@ -317,6 +317,114 @@ def predict(
     
     logging.info("Predictions generated!")
 
+
+@app.command("export-rasters")
+def export_rasters_cmd(
+    raster_paths: List[Path] = typer.Argument(
+        ...,
+        help="One or more GeoTIFF paths to export.",
+    ),
+    output_dir: Path = typer.Option(
+        ...,
+        "--output-dir",
+        "-o",
+        help="Directory for exported files.",
+    ),
+    output_crs: Optional[str] = typer.Option(
+        None,
+        "--output-crs",
+        help='Target CRS (e.g. EPSG:3857). Omit to keep source CRS/grid.',
+    ),
+    as_cog: bool = typer.Option(
+        False,
+        "--cog/--no-cog",
+        help="Cloud Optimized GeoTIFF encoding (orthogonal to --output-crs).",
+    ),
+    resampling: str = typer.Option(
+        "bilinear",
+        "--resampling",
+        help="Warp resampling when using --output-crs: nearest, bilinear, cubic, average.",
+    ),
+    verbose: bool = False,
+) -> None:
+    """Reproject and/or COG-wrap rasters (does not alter ``sdm predict`` outputs)."""
+    from sdm.commands.modelling.export_rasters import export_raster_paths
+
+    setup_logging(verbose=verbose)
+    try:
+        written = export_raster_paths(
+            raster_paths,
+            output_dir,
+            output_crs=output_crs,
+            as_cog=as_cog,
+            resampling=resampling,
+            quiet_cog=not verbose,
+        )
+    except ValueError as e:
+        typer.secho(str(e), err=True)
+        raise typer.Exit(code=1) from e
+
+    for path in written:
+        logging.info("Wrote %s", path)
+
+
+@app.command("export-predictions")
+def export_predictions_cmd(
+    output_dir: Path = typer.Option(
+        ...,
+        "--output-dir",
+        "-o",
+        help="Directory for exported copies.",
+    ),
+    predictions_dir: Path = typer.Option(
+        Path(PROJECT_CONFIG.paths.predictions),
+        "--predictions-dir",
+        help="Folder with all_predictions.tif and optional prediction_*.tif.",
+    ),
+    output_crs: Optional[str] = typer.Option(
+        None,
+        "--output-crs",
+        help="Target CRS (e.g. EPSG:3857). Omit to keep source CRS.",
+    ),
+    as_cog: bool = typer.Option(
+        False,
+        "--cog/--no-cog",
+        help="Cloud Optimized GeoTIFF encoding.",
+    ),
+    no_splits: bool = typer.Option(
+        False,
+        "--no-splits",
+        help="Only export all_predictions.tif (skip prediction_*.tif bands).",
+    ),
+    resampling: str = typer.Option(
+        "bilinear",
+        "--resampling",
+        help="Warp resampling when using --output-crs.",
+    ),
+    verbose: bool = False,
+) -> None:
+    """Export combined + per-model prediction rasters for sharing."""
+    from sdm.commands.modelling.export_rasters import export_predictions_bundle
+
+    setup_logging(verbose=verbose)
+    try:
+        written = export_predictions_bundle(
+            predictions_dir,
+            output_dir,
+            output_crs=output_crs,
+            as_cog=as_cog,
+            resampling=resampling,
+            include_splits=not no_splits,
+            quiet_cog=not verbose,
+        )
+    except (ValueError, FileNotFoundError) as e:
+        typer.secho(str(e), err=True)
+        raise typer.Exit(code=1) from e
+
+    for path in written:
+        logging.info("Wrote %s", path)
+
+
 @app.command()
 def visualize(
     run_summary_path: Path = typer.Option(

--- a/sdm/commands/modelling/export_rasters.py
+++ b/sdm/commands/modelling/export_rasters.py
@@ -6,6 +6,8 @@ import logging
 from pathlib import Path
 from typing import Iterable, List, Optional
 
+from rasterio.enums import Resampling
+
 from sdm.raster.io import export_geotiff
 
 logger = logging.getLogger(__name__)

--- a/sdm/commands/modelling/export_rasters.py
+++ b/sdm/commands/modelling/export_rasters.py
@@ -1,0 +1,121 @@
+"""Export GeoTIFFs for sharing: optional CRS change and optional COG encoding (orthogonal flags)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from sdm.raster.io import export_geotiff
+
+logger = logging.getLogger(__name__)
+
+_RESAMPLING_MAP = {
+    "nearest": Resampling.nearest,
+    "bilinear": Resampling.bilinear,
+    "cubic": Resampling.cubic,
+    "average": Resampling.average,
+}
+
+
+def _output_suffix(output_crs: Optional[str], as_cog: bool) -> str:
+    parts: List[str] = []
+    if output_crs:
+        parts.append(output_crs.replace(":", "").replace(" ", ""))
+    if as_cog:
+        parts.append("cog")
+    return ("_" + "_".join(parts)) if parts else ""
+
+
+def export_raster_paths(
+    raster_paths: Iterable[Path],
+    output_dir: Path,
+    *,
+    output_crs: Optional[str] = None,
+    as_cog: bool = False,
+    resampling: str = "bilinear",
+    quiet_cog: bool = True,
+) -> List[Path]:
+    """Export each raster into *output_dir* with suffix from CRS / COG choices.
+
+    Raises:
+        ValueError: If neither ``output_crs`` nor ``as_cog`` is set (nothing to do).
+        FileNotFoundError: If an input path is missing.
+    """
+    if output_crs is None and not as_cog:
+        raise ValueError(
+            "Nothing to do: pass output_crs (reproject) and/or as_cog=True (COG encode)."
+        )
+
+    try:
+        rs = _RESAMPLING_MAP[resampling.lower()]
+    except KeyError as e:
+        raise ValueError(
+            f"Unknown resampling {resampling!r}; choose from {sorted(_RESAMPLING_MAP)}"
+        ) from e
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    suffix = _output_suffix(output_crs, as_cog)
+    written: List[Path] = []
+
+    for src in raster_paths:
+        src = Path(src)
+        if not src.is_file():
+            raise FileNotFoundError(f"Raster not found: {src}")
+
+        dst = output_dir / f"{src.stem}{suffix}.tif"
+        logger.info(
+            "Export %s -> %s (output_crs=%s, as_cog=%s)",
+            src,
+            dst,
+            output_crs or "(source)",
+            as_cog,
+        )
+        export_geotiff(
+            src,
+            dst,
+            dst_crs=output_crs,
+            as_cog=as_cog,
+            resampling=rs,
+            quiet=quiet_cog,
+        )
+        written.append(dst)
+
+    return written
+
+
+def export_predictions_bundle(
+    predictions_dir: Path,
+    output_dir: Path,
+    *,
+    output_crs: Optional[str] = None,
+    as_cog: bool = False,
+    resampling: str = "bilinear",
+    include_splits: bool = True,
+    quiet_cog: bool = True,
+) -> List[Path]:
+    """Convenience: export ``all_predictions.tif`` and optionally ``prediction_*.tif`` splits."""
+    preds = predictions_dir / "all_predictions.tif"
+    paths: List[Path] = []
+    if preds.is_file():
+        paths.append(preds)
+    else:
+        logger.warning("Missing combined predictions raster: %s", preds)
+
+    if include_splits:
+        paths.extend(sorted(predictions_dir.glob("prediction_*.tif")))
+
+    if not paths:
+        raise FileNotFoundError(
+            f"No prediction rasters found under {predictions_dir} "
+            "(expected all_predictions.tif and/or prediction_*.tif)."
+        )
+
+    return export_raster_paths(
+        paths,
+        output_dir,
+        output_crs=output_crs,
+        as_cog=as_cog,
+        resampling=resampling,
+        quiet_cog=quiet_cog,
+    )

--- a/sdm/commands/modelling/export_rasters.py
+++ b/sdm/commands/modelling/export_rasters.py
@@ -59,13 +59,18 @@ def export_raster_paths(
     output_dir.mkdir(parents=True, exist_ok=True)
     suffix = _output_suffix(output_crs, as_cog)
     written: List[Path] = []
+    stem_counts: dict[str, int] = {}
 
     for src in raster_paths:
         src = Path(src)
         if not src.is_file():
             raise FileNotFoundError(f"Raster not found: {src}")
 
-        dst = output_dir / f"{src.stem}{suffix}.tif"
+        base_key = f"{src.stem}{suffix}"
+        idx = stem_counts.get(base_key, 0)
+        stem_counts[base_key] = idx + 1
+        disambig = "" if idx == 0 else f"_{idx + 1}"
+        dst = output_dir / f"{src.stem}{suffix}{disambig}.tif"
         logger.info(
             "Export %s -> %s (output_crs=%s, as_cog=%s)",
             src,

--- a/sdm/raster/io.py
+++ b/sdm/raster/io.py
@@ -1,6 +1,16 @@
 from pathlib import Path
 from typing import Dict, Any, Optional, Tuple, Union
 import logging
+import os
+import shutil
+import tempfile
+
+import numpy as np
+import rasterio as rio
+from rasterio.crs import CRS
+from rasterio.enums import Resampling
+from rasterio.transform import array_bounds
+from rasterio.warp import calculate_default_transform, reproject
 
 from rio_cogeo.cogeo import cog_translate
 from rio_cogeo.profiles import cog_profiles
@@ -9,6 +19,147 @@ import xarray as xr
 import rioxarray as rxr
 
 logger = logging.getLogger(__name__)
+
+
+def _deflate_profile_for_dtype(dtype: Union[np.dtype, str]) -> Dict[str, Any]:
+    """Deflate COG kwargs matched to raster dtype (float → predictor 3)."""
+    kw = cog_profiles.get("deflate").copy()
+    dt = np.dtype(dtype)
+    kw.update(dtype=np.dtype(dtype).name)
+    if np.issubdtype(dt, np.floating):
+        kw["predictor"] = 3
+    elif np.issubdtype(dt, np.integer):
+        kw["predictor"] = 2
+    else:
+        kw["predictor"] = 1
+    return kw
+
+
+def _resolve_target_crs(
+    dst_crs: Optional[Union[str, int, CRS]],
+    src_crs: Optional[CRS],
+) -> CRS:
+    if dst_crs is None:
+        if src_crs is None:
+            raise ValueError("Source raster has no CRS; pass dst_crs explicitly.")
+        return src_crs
+    if isinstance(dst_crs, CRS):
+        return dst_crs
+    if isinstance(dst_crs, int):
+        return CRS.from_epsg(dst_crs)
+    return CRS.from_user_input(dst_crs)
+
+
+def export_geotiff(
+    src_path: Union[str, Path],
+    dst_path: Union[str, Path],
+    *,
+    dst_crs: Optional[Union[str, int, CRS]] = None,
+    as_cog: bool = False,
+    resampling: Resampling = Resampling.bilinear,
+    quiet: bool = True,
+) -> None:
+    """Optionally reproject and/or encode a GeoTIFF as a COG.
+
+    ``dst_crs`` and ``as_cog`` are independent: set either or both.
+
+    * ``dst_crs=None`` keeps the source CRS/grid (no warp).
+    * ``as_cog=False`` writes a plain tiled/deflate GeoTIFF when warping; otherwise copies the file when nothing else applies.
+
+    Args:
+        src_path: Input raster path.
+        dst_path: Output path (must differ from ``src_path``).
+        dst_crs: Target CRS (e.g. ``EPSG:3857`` or ``3857``). ``None`` = match source grid.
+        as_cog: When True, final output is Cloud Optimized GeoTIFF (via ``rio-cogeo``).
+        resampling: Warp resampling when ``dst_crs`` differs from the source CRS.
+        quiet: Passed through to ``cog_translate``.
+    """
+    src_path = Path(src_path).resolve()
+    dst_path = Path(dst_path).resolve()
+    if src_path == dst_path:
+        raise ValueError(f"Destination must differ from source ({src_path})")
+
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with rio.open(src_path) as src:
+        if src.crs is None:
+            raise ValueError(f"Raster has no CRS: {src_path}")
+        target_crs = _resolve_target_crs(dst_crs, src.crs)
+        needs_reproject = target_crs != src.crs
+
+        if needs_reproject:
+            dst_transform, dst_width, dst_height = calculate_default_transform(
+                src.crs,
+                target_crs,
+                src.width,
+                src.height,
+                *array_bounds(src.height, src.width, src.transform),
+            )
+            meta = src.meta.copy()
+            meta.update(
+                {
+                    "driver": "GTiff",
+                    "crs": target_crs,
+                    "transform": dst_transform,
+                    "width": dst_width,
+                    "height": dst_height,
+                    "compress": "deflate",
+                    "tiled": True,
+                    "BIGTIFF": "IF_NEEDED",
+                }
+            )
+
+            fd, tmp_name = tempfile.mkstemp(suffix=".tif", dir=str(dst_path.parent))
+            os.close(fd)
+            warped_path = Path(tmp_name)
+            try:
+                with rio.open(warped_path, "w", **meta) as dst:
+                    for i in range(1, src.count + 1):
+                        reproject(
+                            source=rio.band(src, i),
+                            destination=rio.band(dst, i),
+                            src_transform=src.transform,
+                            src_crs=src.crs,
+                            dst_transform=dst_transform,
+                            dst_crs=target_crs,
+                            resampling=resampling,
+                            src_nodata=src.nodata,
+                            dst_nodata=src.nodata,
+                        )
+                    dst.descriptions = src.descriptions
+
+                if as_cog:
+                    cog_kw = _deflate_profile_for_dtype(meta["dtype"])
+                    cog_translate(
+                        warped_path,
+                        dst_path,
+                        cog_kw,
+                        nodata=meta.get("nodata"),
+                        overview_resampling="nearest",
+                        quiet=quiet,
+                    )
+                else:
+                    shutil.move(str(warped_path), str(dst_path))
+                    warped_path = None  # suppress unlink in finally
+            finally:
+                if warped_path is not None:
+                    warped_path.unlink(missing_ok=True)
+            return
+
+        # Same CRS/grid as source
+        if as_cog:
+            cog_kw = _deflate_profile_for_dtype(src.profile["dtype"])
+            cog_translate(
+                src_path,
+                dst_path,
+                cog_kw,
+                nodata=src.nodata,
+                overview_resampling="nearest",
+                quiet=quiet,
+            )
+            return
+
+        shutil.copy2(src_path, dst_path)
 
 
 def translate_to_cog(

--- a/tests/test_export_geotiff.py
+++ b/tests/test_export_geotiff.py
@@ -1,0 +1,96 @@
+"""Tests for ``export_geotiff`` and prediction export helpers."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_bounds
+from rio_cogeo.cogeo import cog_validate
+
+from sdm.commands.modelling.export_rasters import export_raster_paths
+from sdm.raster.io import export_geotiff
+
+
+@pytest.fixture
+def tiny_gtiff_27700(tmp_path: Path) -> Path:
+    path = tmp_path / "demo.tif"
+    h, w = 8, 10
+    data = np.linspace(0, 1, h * w, dtype=np.float32).reshape(h, w)
+    transform = from_bounds(
+        400_000,
+        500_000,
+        400_000 + w * 100,
+        500_000 + h * 100,
+        w,
+        h,
+    )
+    profile = {
+        "driver": "GTiff",
+        "width": w,
+        "height": h,
+        "count": 1,
+        "dtype": "float32",
+        "crs": "EPSG:27700",
+        "transform": transform,
+        "nodata": -9999.0,
+        "compress": "deflate",
+        "tiled": True,
+    }
+    with rasterio.open(path, "w", **profile) as dst:
+        dst.write(data, 1)
+    return path
+
+
+def test_export_geotiff_cog_same_crs(tiny_gtiff_27700: Path, tmp_path: Path) -> None:
+    dst = tmp_path / "out_cog.tif"
+    export_geotiff(tiny_gtiff_27700, dst, as_cog=True)
+    with rasterio.open(dst) as ds:
+        assert ds.crs.to_epsg() == 27700
+    ok, _, errs = cog_validate(dst, quiet=True)
+    assert ok, errs
+
+
+def test_export_geotiff_warp_3857_plain(tiny_gtiff_27700: Path, tmp_path: Path) -> None:
+    dst = tmp_path / "out_warp.tif"
+    export_geotiff(tiny_gtiff_27700, dst, dst_crs="EPSG:3857", as_cog=False)
+    with rasterio.open(dst) as ds:
+        assert ds.crs.to_epsg() == 3857
+
+
+def test_export_geotiff_warp_3857_cog(tiny_gtiff_27700: Path, tmp_path: Path) -> None:
+    dst = tmp_path / "out_both.tif"
+    export_geotiff(tiny_gtiff_27700, dst, dst_crs="EPSG:3857", as_cog=True)
+    with rasterio.open(dst) as ds:
+        assert ds.crs.to_epsg() == 3857
+    ok, _, errs = cog_validate(dst, quiet=True)
+    assert ok, errs
+
+
+def test_export_geotiff_same_src_dst_raises(tiny_gtiff_27700: Path) -> None:
+    with pytest.raises(ValueError, match="Destination must differ"):
+        export_geotiff(tiny_gtiff_27700, tiny_gtiff_27700, as_cog=True)
+
+
+def test_export_raster_paths_requires_action(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Nothing to do"):
+        export_raster_paths([], tmp_path / "out")
+
+
+def test_export_raster_paths_duplicate_stems(tiny_gtiff_27700: Path, tmp_path: Path) -> None:
+    other = tmp_path / "nested" / "demo.tif"
+    other.parent.mkdir()
+    shutil.copy2(tiny_gtiff_27700, other)
+    out_dir = tmp_path / "exports"
+    paths = export_raster_paths(
+        [tiny_gtiff_27700, other],
+        out_dir,
+        output_crs="EPSG:3857",
+        as_cog=False,
+    )
+    assert len(paths) == 2
+    assert paths[0].name == "demo_EPSG3857.tif"
+    assert paths[1].name == "demo_EPSG3857_2.tif"


### PR DESCRIPTION
## Summary
- Keeps **`sdm predict`** writing plain GeoTIFFs on the **same CRS/grid as the EV stack** (e.g. EPSG:27700).
- Adds **`export_geotiff`** in `sdm/raster/io.py` where **`dst_crs`** (reproject) and **`as_cog`** (rio-cogeo) are **independent**.
- Adds **`sdm export-rasters`** for explicit input paths and **`sdm export-predictions`** as a convenience over `all_predictions.tif` + optional `prediction_*.tif` splits.

## Usage examples
```bash
# Web Mercator COGs for sharing (warp + COG — both flags explicit)
sdm export-predictions -o data/sdm_predictions/web_share --output-crs EPSG:3857 --cog

# COG-only re-packaging on the existing grid (no warp)
sdm export-rasters data/sdm_predictions/all_predictions.tif -o data/sdm_predictions/cog_native --cog

# Warp only (plain deflate GeoTIFF, not COG)
sdm export-rasters data/sdm_predictions/all_predictions.tif -o data/sdm_predictions/warp_only --output-crs EPSG:3857 --no-cog
```

## Test plan
- [ ] `uv run sdm export-rasters --help` / `export-predictions --help`
- [ ] Run export on a small raster with `--output-crs EPSG:3857`, `--cog`, and combinations; open outputs in QGIS / `rio cogeo validate`

Made with [Cursor](https://cursor.com)